### PR TITLE
Implement Country CRUD Operations with Query Parameter Filtering

### DIFF
--- a/src/main/java/org/spiceboys/Travel/Diary/controller/CountryController.java
+++ b/src/main/java/org/spiceboys/Travel/Diary/controller/CountryController.java
@@ -4,6 +4,7 @@ import org.spiceboys.Travel.Diary.service.CountryService;
 import org.spiceboys.Travel.Diary.model.Country;
 import org.spiceboys.Travel.Diary.service.UserService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -11,7 +12,6 @@ import java.util.Map;
 import java.util.ArrayList;
 
 @RestController
-@RequestMapping("/api/countries")
 public class CountryController {
     private final CountryService countryService;
 
@@ -19,16 +19,34 @@ public class CountryController {
         this.countryService = countryService;
     }
 
-    @PostMapping
-    public ResponseEntity<Country> createCountry(@RequestBody Country country){
+    @PostMapping("/countries")
+    public ResponseEntity<Country> createCountry(
+            @RequestBody Country country
+    ){
         Country createdCountry = countryService.createCountry(country);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdCountry);
     }
 
-    @GetMapping("/country-name/{countryName}")
-    public ResponseEntity<Country> fetchCountryByCountryName(@PathVariable String countryName){
+    @GetMapping("/countries/{countryName}")
+    public ResponseEntity<Country> fetchCountryByCountryName(
+            @PathVariable String countryName
+    ){
         Country fetchedCountry = countryService.getCountryByCountryName(countryName);
         return ResponseEntity.status(HttpStatus.OK).body(fetchedCountry);
     }
 
+    @GetMapping("/countries")
+    public ResponseEntity<List<Country>> getAllCountries(
+            @RequestParam(required = false) String countryName,
+            @RequestParam(required = false) String description,
+            @RequestParam(required = false) String countryPicUrl) {
+
+        List<Country> countries = countryService.getAllCountries(countryName, description, countryPicUrl);
+
+        if (countries.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } else {
+            return ResponseEntity.status(HttpStatus.OK).body(countries);
+        }
+    }
 }

--- a/src/main/java/org/spiceboys/Travel/Diary/repository/CountryRepository.java
+++ b/src/main/java/org/spiceboys/Travel/Diary/repository/CountryRepository.java
@@ -3,8 +3,24 @@ package org.spiceboys.Travel.Diary.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.spiceboys.Travel.Diary.model.Country;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CountryRepository extends JpaRepository<Country, Integer> {
     Optional<Country> findCountryByCountryName(String countryName);
+
+    List<Country> findByCountryNameContaining(String countryName);
+
+    List<Country> findByDescriptionContaining(String description);
+
+    List<Country> findByCountryPicUrlContaining(String countryPicUrl);
+
+    List<Country> findByCountryNameContainingAndDescriptionContaining(String countryName, String description);
+
+    List<Country> findByCountryNameContainingAndCountryPicUrlContaining(String countryName, String countryPicUrl);
+
+    List<Country> findByDescriptionContainingAndCountryPicUrlContaining(String description, String countryPicUrl);
+
+    List<Country> findByCountryNameContainingAndDescriptionContainingAndCountryPicUrlContaining(
+            String countryName, String description, String countryPicUrl);
 }

--- a/src/main/java/org/spiceboys/Travel/Diary/seeder/DataSeeder.java
+++ b/src/main/java/org/spiceboys/Travel/Diary/seeder/DataSeeder.java
@@ -1,0 +1,96 @@
+package org.spiceboys.Travel.Diary.seeder;
+
+import org.spiceboys.Travel.Diary.model.Country;
+import org.spiceboys.Travel.Diary.repository.CountryRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataSeeder implements CommandLineRunner {
+
+    private final CountryRepository countryRepository;
+
+    public DataSeeder(CountryRepository countryRepository) {
+        this.countryRepository = countryRepository;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (countryRepository.count() == 0) {
+            Country france = new Country(
+                    "France",
+                    "A beautiful country known for its cuisine and the Eiffel Tower.",
+                    "https://upload.wikimedia.org/wikipedia/en/c/c3/Flag_of_France.svg"
+            );
+
+            Country japan = new Country(
+                    "Japan",
+                    "A country rich in tradition and technology.",
+                    "https://upload.wikimedia.org/wikipedia/en/9/9e/Flag_of_Japan.svg"
+            );
+
+            Country brazil = new Country(
+                    "Brazil",
+                    "A country famous for its carnivals and the Amazon rainforest.",
+                    "https://upload.wikimedia.org/wikipedia/en/0/05/Flag_of_Brazil.svg"
+            );
+
+            Country australia = new Country(
+                    "Australia",
+                    "A vast country known for its unique wildlife and the Great Barrier Reef.",
+                    "https://upload.wikimedia.org/wikipedia/commons/b/b9/Flag_of_Australia.svg"
+            );
+
+            Country canada = new Country(
+                    "Canada",
+                    "A beautiful country known for its vast wilderness and the Rocky Mountains.",
+                    "https://upload.wikimedia.org/wikipedia/commons/c/cf/Flag_of_Canada.svg"
+            );
+
+            Country india = new Country(
+                    "India",
+                    "A country rich in culture, history, and diverse landscapes.",
+                    "https://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg"
+            );
+
+            Country italy = new Country(
+                    "Italy",
+                    "A country known for its art, architecture, and delicious food.",
+                    "https://upload.wikimedia.org/wikipedia/commons/0/03/Flag_of_Italy.svg"
+            );
+
+            Country mexico = new Country(
+                    "Mexico",
+                    "A country with a rich history, vibrant culture, and delicious cuisine.",
+                    "https://upload.wikimedia.org/wikipedia/commons/f/fc/Flag_of_Mexico.svg"
+            );
+
+            Country germany = new Country(
+                    "Germany",
+                    "A country known for its engineering, history, and cultural contributions.",
+                    "https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Germany.svg"
+            );
+
+            Country southKorea = new Country(
+                    "South Korea",
+                    "A country that blends modern technology with traditional culture.",
+                    "https://upload.wikimedia.org/wikipedia/commons/0/0f/Flag_of_South_Korea.svg"
+            );
+
+            countryRepository.save(france);
+            countryRepository.save(japan);
+            countryRepository.save(brazil);
+            countryRepository.save(australia);
+            countryRepository.save(canada);
+            countryRepository.save(india);
+            countryRepository.save(italy);
+            countryRepository.save(mexico);
+            countryRepository.save(germany);
+            countryRepository.save(southKorea);
+
+            System.out.println("✅ Countries table seeded!");
+        } else {
+            System.out.println("ℹ️ Countries table already has data, skipping seed.");
+        }
+    }
+}

--- a/src/main/java/org/spiceboys/Travel/Diary/service/CountryService.java
+++ b/src/main/java/org/spiceboys/Travel/Diary/service/CountryService.java
@@ -21,10 +21,31 @@ public class CountryService {
 
     public Country getCountryByCountryName(String countryName){
         Optional<Country> countryOptional = countryRepository.findCountryByCountryName(countryName);
-        if (countryOptional.isPresent()){
+        if (countryOptional.isPresent()) {
             return countryOptional.get();
-        }else{
-      throw new ContentNotFoundException("Country does not exist");
+        } else {
+            throw new ContentNotFoundException("Country does not exist");
+        }
+    }
+
+    public List<Country> getAllCountries(String countryName, String description, String countryPicUrl) {
+        if (countryName != null && description != null && countryPicUrl != null) {
+            return countryRepository.findByCountryNameContainingAndDescriptionContainingAndCountryPicUrlContaining(
+                    countryName, description, countryPicUrl);
+        } else if (countryName != null && description != null) {
+            return countryRepository.findByCountryNameContainingAndDescriptionContaining(countryName, description);
+        } else if (countryName != null && countryPicUrl != null) {
+            return countryRepository.findByCountryNameContainingAndCountryPicUrlContaining(countryName, countryPicUrl);
+        } else if (description != null && countryPicUrl != null) {
+            return countryRepository.findByDescriptionContainingAndCountryPicUrlContaining(description, countryPicUrl);
+        } else if (countryName != null) {
+            return countryRepository.findByCountryNameContaining(countryName);
+        } else if (description != null) {
+            return countryRepository.findByDescriptionContaining(description);
+        } else if (countryPicUrl != null) {
+            return countryRepository.findByCountryPicUrlContaining(countryPicUrl);
+        } else {
+            return countryRepository.findAll();  // Return all countries if no parameters are provided
         }
     }
 }


### PR DESCRIPTION
POST /countries: Added an endpoint to create a new country by receiving country data in the request body. The new country is saved to the database and the response includes the created country.

GET /countries: Added a filtering mechanism that supports multiple query parameters (countryName, description, countryPicUrl) to filter countries. The service layer handles combinations of these parameters and returns the filtered results.

Implemented corresponding repository methods to support filtering by each combination of query parameters.

Tested the endpoints using Postman to ensure correct behavior with varying query parameters and the creation of new countries.